### PR TITLE
global_wrapper: fix build failure against gcc-10

### DIFF
--- a/global_wrapper.c
+++ b/global_wrapper.c
@@ -26,6 +26,10 @@
 #include <time.h>
 #include <argp.h>
 #include <argz.h>
+
+char *domain;
+char *long_domain;
+
 static struct argp_option opt_global[] = {
  {"usage",'u',0,OPTION_NO_USAGE,0},
  {"help",'?',0,OPTION_NO_USAGE,0},

--- a/global_wrapper.h
+++ b/global_wrapper.h
@@ -14,7 +14,7 @@
    
 #ifndef GLOBAL_RAPER
 #define GLOBAL_RAPER 
-char *domain;
-char *long_domain;
+extern char *domain;
+extern char *long_domain;
 void cmd_global(int argc, char**argv);
 #endif


### PR DESCRIPTION
gcc-10 enabled -fno-common by default. This happens to catch unintended
multiple definitions:

```
ld: ccD2iWhk.o:(.bss+0x8): multiple definition of `domain';
  ccgA4lYl.o:(.bss+0x8): first defined here
ld: ccD2iWhk.o:(.bss+0x0): multiple definition of `long_domain';
  ccgA4lYl.o:(.bss+0x0): first defined here

```

The change flips definition to declaration and moves definition
to related .c file.